### PR TITLE
Adding beta API

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,10 @@
+{:config-paths ["../resources/clj-kondo.exports/biiwide/naphthalimide/"]
+ :linters {:non-arg-vec-return-type-hint
+           {:level :off}
+
+           :unresolved-symbol
+           {:exclude [(clojure.test/is [match?])]}
+
+           :unsorted-required-namespaces
+           {:level :warn}}
+ :skip-comments true}

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+.clj-kondo/.cache
 .classpath
 .project
 .settings/

--- a/README.md
+++ b/README.md
@@ -4,45 +4,55 @@ Idiomatic Clojure support for OpenTracing.
 
 ## Usage
 
+### Dependency information
+
+```clojure
+[biiwide/naphthalimide "0.0.4"]
 ```
-(require '[naphthalimide.alpha :as trace])
+
+### Sample Usage
+
+```clojure
+(require '[naphthalimide.beta :as trace])
 ```
 
 An anonymous, traced function:
 
-```
+```clojure
 (let [f (trace/fn important
-          [a b]
+          [^::trace/tag a b]
           (+ a b))]
   (f 1 2))
 ```
-All function arguments will be passed as tags.
+
+Function arguments annotaed with :naphthalimide.beta/tag will be
+added to the span as tags.
 
 A defined, traced function:
 
-```
+```clojure
 (trace/defn my-traced-function
   "Documentation..."
-  ([a] a)
-  ([a b] (+ a b))
+  ([^::trace/tag a] a)
+  ([^::trace/tag a ^::trace/tag b] (+ a b)))
 ```
 
-A traced section of code:
+A traced block of code:
 
-```
+```clojure
 (fn [a b]
-  (trace/span my-inline-span
-              [c (str a b)
-               d (str b a)]
-    [c d]))
+  (trace/let-span my-inline-span
+                  [c (str a b)
+		   d (str b a)]
+    (list c d)))
 ```
 
-The span will be tagged with `c` and `d`.
+The span `my-inline-span` will be created and tagged with `c` and `d`.
 
 
 ## License
 
-Copyright © 2018 Theodore Cushman
+Copyright © 2022 Theodore Cushman
 
 Distributed under the Eclipse Public License either version 1.0 or (at
 your option) any later version.

--- a/project.clj
+++ b/project.clj
@@ -7,16 +7,17 @@
   :license {:name "Eclipse Public License 2.0"
             :url "https://www.eclipse.org/legal/epl-2.0"}
 
-  :dependencies [[io.opentracing/opentracing-api "0.31.0"]
-                 [io.opentracing/opentracing-util "0.31.0"]
-                 [org.clojure/clojure "1.8.0"]
-                 [potemkin "0.4.5"]
-                 ]
+  :plugins [[lein-ancient "1.0.0-RC3"]]
+
+  :dependencies [[io.opentracing/opentracing-api "0.33.0"]
+                 [io.opentracing/opentracing-util "0.33.0"]
+                 [org.clojure/clojure "1.8.0" :scope "provided"]
+                 [potemkin "0.4.5"]]
 
   :global-vars {*warn-on-reflection* true}
   
-  :profiles {:dev {:dependencies [[io.opentracing/opentracing-mock "0.31.0"]
-                                  [com.uber.jaeger/jaeger-core "0.26.0"]]
+  :profiles {:dev {:dependencies [[io.opentracing/opentracing-mock "0.33.0"]
+                                  [com.uber.jaeger/jaeger-core "0.27.0"]]
                    }}
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]

--- a/project.clj
+++ b/project.clj
@@ -17,10 +17,14 @@
 
   :global-vars {*warn-on-reflection* true}
   
+  :aliases {"kondo"
+            ["with-profile" "clj-kondo" "run" "-m" "clj-kondo.main" "--lint" "src:test" "--copy-configs"]}
+
   :profiles {:dev {:dependencies [[com.uber.jaeger/jaeger-core "0.27.0"]
                                   [io.opentracing/opentracing-mock "0.33.0"]
-                                  [nubank/matcher-combinators "3.5.0"]]
-                   }}
+                                  [nubank/matcher-combinators "3.5.0"]]}
+             :clj-kondo {:dependencies ^:replace [[clj-kondo "2022.08.03"]]}}
+
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
                   ["vcs" "commit"]

--- a/project.clj
+++ b/project.clj
@@ -27,10 +27,13 @@
 
   :release-tasks [["vcs" "assert-committed"]
                   ["change" "version" "leiningen.release/bump-version" "release"]
+                  ["file-replace" "README.md"
+                   "\\[biiwide/naphthalimide \"" "\"]"
+                   "version"]
                   ["vcs" "commit"]
                   ["vcs" "tag" "--no-sign"]
                   ["deploy" "clojars"]
                   ["change" "version" "leiningen.release/bump-version"]
                   ["vcs" "commit"]
-                  ["vcs" "push"]]  
+                  ["vcs" "push"]]
   )

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,8 @@
   :license {:name "Eclipse Public License 2.0"
             :url "https://www.eclipse.org/legal/epl-2.0"}
 
-  :plugins [[lein-ancient "1.0.0-RC3"]]
+  :plugins [[lein-ancient "1.0.0-RC3"]
+            [lein-cloverage "1.2.4"]]
 
   :dependencies [[io.opentracing/opentracing-api "0.33.0"]
                  [io.opentracing/opentracing-util "0.33.0"]

--- a/resources/clj-kondo.exports/biiwide/naphthalimide/config.edn
+++ b/resources/clj-kondo.exports/biiwide/naphthalimide/config.edn
@@ -1,0 +1,11 @@
+{:analysis {:context true
+            :keywords true}
+ :hooks {:analyze-call {naphthalimide.alpha/defn     naphthalimide.hooks/analyze-defn
+                        naphthalimide.alpha/fn       naphthalimide.hooks/analyze-fn
+                        naphthalimide.alpha/let-span naphthalimide.hooks/analyze-let-span
+                        naphthalimide.alpha/span     naphthalimide.hooks/analyze-span
+                        naphthalimide.beta/defn      naphthalimide.hooks/analyze-beta-defn
+                        naphthalimide.beta/fn        naphthalimide.hooks/analyze-beta-fn
+                        naphthalimide.beta/let-span  naphthalimide.hooks/analyze-let-span
+                        naphthalimide.beta/span      naphthalimide.hooks/analyze-span}}
+ :lint-as {naphthalimide.internal/definline* clojure.core/defmacro}}

--- a/resources/clj-kondo.exports/biiwide/naphthalimide/naphthalimide/hooks.clj
+++ b/resources/clj-kondo.exports/biiwide/naphthalimide/naphthalimide/hooks.clj
@@ -1,0 +1,154 @@
+(ns naphthalimide.hooks
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.pprint :refer [pprint]]))
+
+(defonce span-names (atom {}))
+
+(defn register-span! [qualified-span-name]
+  (let [n (get (swap! span-names update qualified-span-name (fnil inc 0))
+               qualified-span-name)]
+    (= 1 n)))
+
+(defn qualify-span-name [an-ns a-sym]
+  (symbol (str an-ns) (name a-sym)))
+
+(defn analyze-span
+  [{:keys [node ns] :as input}]
+  (let [[span-name & body] (rest (:children node))]
+    (when-not (register-span! (qualify-span-name ns (api/sexpr span-name)))
+      (api/reg-finding! (assoc (meta span-name)
+                               :message "Duplicate span-name declared in span."
+                               :type :naphthalimide/duplicate-spans)))
+    {:node (with-meta (api/list-node
+                        (cons (api/token-node 'do)
+                              body))
+                      (meta node))}))
+
+(defn analyze-let-span
+  [{:keys [node ns]}]
+  (let [[span-name bindings & body] (rest (:children node))]
+    (when-not (register-span! (qualify-span-name ns (api/sexpr span-name)))
+      (api/reg-finding! (assoc (meta span-name)
+                               :message "Duplicate span-name declared in let-span."
+                               :type :naphthalimide/duplicate-spans)))
+    {:node (with-meta (api/list-node
+                        (list* (api/token-node 'clojure.core/let)
+                               bindings
+                               body))
+                      (meta node))}))
+
+(defn analyze-fn
+  [{:keys [node ns]}]
+  (let [[fn-name & more] (rest (:children node))]
+    (when-not (register-span! (qualify-span-name ns (api/sexpr fn-name)))
+      (api/reg-finding! (assoc (meta fn-name)
+                               :message "Duplicate span-name declared for lambda"
+                               :type :naphthalimide/duplicate-spans)))
+    {:node (with-meta (api/list-node
+                        (list* (api/token-node 'clojure.core/fn)
+                               fn-name
+                               more))
+                      (meta node))}))
+
+(defn analyze-defn
+  [{:keys [node ns]}]
+  (let [[fn-name & more] (rest (:children node))]
+    (when-not (register-span! (qualify-span-name ns (api/sexpr fn-name)))
+      (api/reg-finding! (assoc (meta fn-name)
+                               :message "Duplicate span-name declared for defn"
+                               :type :naphthalimide/duplicate-spans)))
+    {:node (with-meta (api/list-node
+                        (list* (api/token-node 'clojure.core/defn)
+                               fn-name
+                               more))
+                      (meta node))}))
+
+(defn symbol-node? [x]
+  (some-> x api/sexpr symbol?))
+
+(defn normalize-arities
+  [fn-body]
+  (if (api/vector-node? (first fn-body))
+    [(api/list-node fn-body)]
+    fn-body))
+
+(def node-class?
+  (memoize (fn [clazz] (some #{"interface clj_kondo.impl.rewrite_clj.node.protocols.Node"}
+                             (map str (ancestors clazz))))))
+
+(defn node? [x]
+  (node-class? (class x)))
+
+(defn walk
+  [inner outer form]
+  (cond
+    (node? form)
+    (outer (update form :children #(mapv inner %)))
+    :else (outer form)))
+
+(defn meta-dissoc
+  [node k?]
+  (if-some [md (:meta node)]
+    (assoc node :meta (vec (mapcat (fn [meta-node]
+                                     (cond (api/token-node? meta-node)
+                                           (when (not (k? meta-node))
+                                             [meta-node])
+                                           (api/map-node? meta-node)
+                                           (update meta-node :children
+                                                   (partial mapcat #(when (not (k? (first %))) %)))
+                                           :else
+                                           [meta-node]))
+                                   md)))
+    node))
+
+(defn prewalk
+  [f form]
+  (walk (partial prewalk f) identity (f form)))
+
+(defn alias-keyword
+  [node qualified-kw]
+  (cons qualified-kw nil))
+
+(defn beta-tag? [x]
+  (and (qualified-keyword? x)
+       (= "tag" (name x))))
+
+(defn analyze-beta-fn
+  [{:keys [node ns] :as input}]
+  (let [[fn-name & more] (rest (:children node))
+        arities (normalize-arities more)
+        tag-keys (alias-keyword input :naphthalimide.beta/tag)]
+    (when-not (register-span! (qualify-span-name ns (api/sexpr fn-name)))
+      (api/reg-finding! (assoc (meta fn-name)
+                               :message "Duplicate span-name declared for lambda"
+                               :type :naphthalimide/duplicate-spans)))
+    (assoc input :node
+           (with-meta (api/list-node
+                        (list* (api/token-node 'clojure.core/fn)
+                               fn-name
+                               (mapv (fn [a]
+                                       (let [[argv & body] (:children a)]
+                                         (api/list-node
+                                           (cons (prewalk #(meta-dissoc % (comp beta-tag? api/sexpr))
+                                                          argv)
+                                                 body))))
+                                     arities)))
+                      (meta node)))))
+
+(defn analyze-beta-defn
+  [{:keys [node ns] :as input}]
+  (let [[fn-name & more] (rest (:children node))
+        [doc & more] (if (api/string-node? (first more))
+                       more
+                       (cons (api/token-node "") more))]
+    (assoc input :node
+           (with-meta (api/list-node
+                        [(api/token-node 'clojure.core/def)
+                         fn-name
+                         doc
+                         (with-meta (api/list-node
+                                      (list* (api/token-node 'naphthalimide.beta/fn)
+                                             fn-name
+                                             more))
+                                    (meta node))])
+                      (meta node)))))

--- a/src/naphthalimide/alpha.clj
+++ b/src/naphthalimide/alpha.clj
@@ -2,7 +2,7 @@
   (:refer-clojure :exclude [defn- defn fn fn*])
   (:require [clojure.core :as clj]
             [naphthalimide.alpha.span :as span]
-            [naphthalimide.alpha.tracer :as tracer]
+            naphthalimide.alpha.tracer
             [naphthalimide.internal :refer
              [definline* destruct-syms meta-from
               namespaced-name parse-fn]]
@@ -10,10 +10,9 @@
 
 
 (import-vars
-  (naphthalimide.alpha
-    (tracer global-tracer
-            register-global-tracer!
-            with-tracer)))
+  (naphthalimide.alpha.tracer global-tracer
+                              register-global-tracer!
+                              with-tracer))
 
 
 (def active-span span/active)

--- a/src/naphthalimide/alpha.clj
+++ b/src/naphthalimide/alpha.clj
@@ -4,7 +4,8 @@
             [naphthalimide.alpha.span :as span]
             [naphthalimide.alpha.tracer :as tracer]
             [naphthalimide.internal :refer
-             [parse-fn definline*]]
+             [definline* destruct-syms meta-from
+              namespaced-name parse-fn]]
             [potemkin :refer [import-vars]]))
 
 
@@ -16,30 +17,6 @@
 
 
 (def active-span span/active)
-
-
-(clj/defn- destruct-syms
-  [binding]
-  (remove #{'&}
-          ((clj/fn syms [x]
-             (cond (symbol? x) [x]
-                   (coll? x)   (mapcat syms x)))
-            binding)))
-
-
-(clj/defn- meta-from
-  [expr meta-source]
-  (vary-meta expr merge
-             (meta meta-source)))
-
-
-(clj/defn- namespaced-name
-  [sym]
-  (if (and (instance? clojure.lang.Named sym)
-           (some? (namespace sym)))
-    (str sym)
-    (recur (symbol (str (ns-name *ns*))
-                   (name sym)))))
 
 
 (clj/defmacro span

--- a/src/naphthalimide/alpha/carrier.clj
+++ b/src/naphthalimide/alpha/carrier.clj
@@ -70,7 +70,7 @@
                         tracer
                         (span/active tracer)))
   ([carrier-format-name ^Tracer tracer ^Span span]
-    (if-some [{:keys [format init final]} (carrier-format carrier-format-name)]
+    (when-some [{:keys [format init final]} (carrier-format carrier-format-name)]
       (let [carrier (init)]
         (.inject tracer (span/context span) format carrier)
         (final carrier)))))
@@ -80,6 +80,6 @@
   ([carrier-format-name carrier]
     (extract-context carrier-format-name carrier (tracer/global-tracer)))
   ([carrier-format-name carrier ^Tracer tracer]
-    (if-some [{:keys [format init]} (carrier-format carrier-format-name)]
+    (when-some [{:keys [format init]} (carrier-format carrier-format-name)]
       (.extract tracer format (init carrier)))))
 

--- a/src/naphthalimide/alpha/span.clj
+++ b/src/naphthalimide/alpha/span.clj
@@ -15,11 +15,6 @@
   `(instance? Throwable ~x))
 
 
-(definline ^:private tracer?
-  [x]
-  `(instance? Tracer ~x))
-
-
 (def ^:dynamic *sequence-length* 3)
 
 
@@ -36,7 +31,8 @@
 (extend-protocol HasActiveSpan
   Span
   (-active-span [span] span)
-  (-active-span [^Scope scope]
+  Scope
+  (-active-span [_scope]
     (throw (IllegalArgumentException. "OpenTracing no longer support returning the active Span from a Scope.")))
   ScopeManager
   (-active-span [^ScopeManager scope-mgr]
@@ -109,8 +105,8 @@
 (defn set-tag!
   "Sets a tag on an existing span."
   [^Span span tag-key tag-val]
-  (do (-span-set-tag tag-val (name tag-key) span)
-      span))
+  (-span-set-tag tag-val (name tag-key) span)
+  span)
 
 
 (defn ^java.util.Map event

--- a/src/naphthalimide/alpha/span.clj
+++ b/src/naphthalimide/alpha/span.clj
@@ -6,6 +6,7 @@
   (:import  (io.opentracing References Scope ScopeManager
                             Span SpanContext
                             Tracer Tracer$SpanBuilder)
+            (java.util Map)
             ))
 
 
@@ -31,6 +32,7 @@
 (defprotocol HasActiveSpan
   (^io.opentracing.Span -active-span [source]))
 
+
 (extend-protocol HasActiveSpan
   Span
   (-active-span [span] span)
@@ -49,6 +51,7 @@
 (defprotocol HasContext
   (^io.opentracing.SpanContext context [x] "Return a span context"))
   
+
 (extend-protocol HasContext
   Span
   (context [^Span span] (.context span))
@@ -68,6 +71,7 @@
 (defprotocol TagValue
   (-span-set-tag [value key span])
   (-builder-with-tag [value key span-builder]))
+
 
 (extend-protocol TagValue
   Boolean
@@ -126,9 +130,9 @@
 (defn ^Span log!
   "Log data to a span"
   ([^Span span map-or-message]
-    (.log span (event map-or-message)))
+   (.log span ^Map (event map-or-message)))
   ([^Span span ^long epoch-micros map-or-message]
-    (.log span epoch-micros (event map-or-message))))
+   (.log span epoch-micros ^Map (event map-or-message))))
 
 
 (defn set-baggage-item!

--- a/src/naphthalimide/alpha/tracer/mock.clj
+++ b/src/naphthalimide/alpha/tracer/mock.clj
@@ -20,7 +20,7 @@
   (to-map [^MockSpan$MockContext ctxt]
     (cond-> {:trace-id (.traceId ctxt)
              :span-id  (.spanId ctxt)}
-      (not (empty? (.baggageItems ctxt)))
+      (seq (.baggageItems ctxt))
       (assoc :baggage  (into {} (.baggageItems ctxt))))))
   
 
@@ -53,14 +53,14 @@
       (not (zero? (.parentId span)))
       (assoc :parent-id (.parentId span))
 
-      (not (empty? (.logEntries span)))
+      (seq (.logEntries span))
       (assoc :log (map to-map (.logEntries span)))
 
-      (not (empty? (.references span)))
+      (seq (.references span))
       (assoc :references (map to-map (.references span)))
 
-      (not (empty? (.generatedErrors span)))
-      (assoc :generated-errors (.generatedErrors span))
+      (seq (.generatedErrors span))
+      (assoc :generated-errors (seq (.generatedErrors span)))
       )))
 
 
@@ -68,5 +68,4 @@
   [^MockTracer tracer]
   (mapv to-map
         (.finishedSpans tracer)))
-
 

--- a/src/naphthalimide/beta.clj
+++ b/src/naphthalimide/beta.clj
@@ -1,19 +1,19 @@
 (ns naphthalimide.beta
   (:refer-clojure :exclude [defn- defn fn fn*])
   (:require [clojure.core :as clj]
+            naphthalimide.alpha
             [naphthalimide.alpha.span :as span]
+            naphthalimide.alpha.tracer
             [naphthalimide.internal :refer
              [definline* destruct-syms meta-from parse-fn]]
             [potemkin :refer [import-vars]]))
 
 
 (import-vars
-  [naphthalimide
-    [alpha let-span
-           span
-           [tracer global-tracer
-                   register-global-tracer!
-                   with-tracer]]])
+  (naphthalimide.alpha let-span span)
+  (naphthalimide.alpha.tracer global-tracer
+                              register-global-tracer!
+                              with-tracer))
 
 
 (def active-span span/active)

--- a/src/naphthalimide/beta.clj
+++ b/src/naphthalimide/beta.clj
@@ -1,0 +1,112 @@
+(ns naphthalimide.beta
+  (:refer-clojure :exclude [defn- defn fn fn*])
+  (:require [clojure.core :as clj]
+            [naphthalimide.alpha.span :as span]
+            [naphthalimide.alpha.tracer :as tracer]
+            [naphthalimide.internal :refer
+             [parse-fn definline*]]
+            [potemkin :refer [import-vars]]))
+
+
+(import-vars
+  (naphthalimide
+    (alpha let-span log!
+           set-baggage-item!
+           set-tag! span
+           (tracer global-tracer
+                   register-global-tracer!
+                   with-tracer))))
+
+
+(def active-span span/active)
+
+
+(clj/defn- destruct-syms
+  [binding]
+  (remove #{'&}
+          ((clj/fn syms [x]
+             (cond (symbol? x) [x]
+                   (coll? x)   (mapcat syms x)))
+            binding)))
+
+
+
+(clj/defn- meta-from
+  [expr meta-source]
+  (vary-meta expr merge
+             (meta meta-source)))
+
+
+(clj/defn- namespaced-name
+  [sym]
+  (if (and (instance? clojure.lang.Named sym)
+           (some? (namespace sym)))
+    (str sym)
+    (recur (symbol (str (ns-name *ns*))
+                   (name sym)))))
+
+
+(clj/defmacro fn
+  [fn-name & fn-form]
+  (assert (symbol? fn-name)
+          "Traced Functions must have a name")
+  (let [{:keys [prelude arities]}
+        (parse-fn (cons fn-name fn-form))]
+    (meta-from
+      `(clj/fn ~@prelude
+         ~@(for [arity arities]
+             (let [[argv & body] arity]
+               (meta-from `(~argv
+                             ~(meta-from `(let-span ~fn-name ~(vec (mapcat (partial repeat 2)
+                                                                           (destruct-syms argv)))
+                                                ~@body)
+                                         arity))
+                          arity))))
+      &form)))
+
+
+(clj/defmacro defn
+  [name & defn-form]
+  (let [{:keys [prelude arities]}
+        (parse-fn (cons name defn-form) )]
+    (binding [*print-meta* true]
+      (meta-from `(def ~@prelude
+                    (fn ~name ~@(map #(vary-meta % (constantly nil))
+                                     arities)))
+                 &form))))
+
+
+(comment
+  ;; Register a Jaeger Tracer
+  (register-global-tracer!
+    (-> (com.uber.jaeger.Configuration. "testing")
+        (.withSampler (-> (com.uber.jaeger.Configuration$SamplerConfiguration.)
+                          (.withType "const")
+                          (.withParam 1)))
+        (.withReporter (-> (com.uber.jaeger.Configuration$ReporterConfiguration.)
+                           (.withLogSpans true)
+                           (.withFlushInterval (int 2000))
+                           (.withMaxQueueSize (int 10000))
+                           (.withSender (-> (com.uber.jaeger.Configuration$SenderConfiguration.)
+                                            (.withAgentHost "127.0.0.1")
+                                            (.withAgentPort (int 5775))))))
+        (.getTracer)))
+
+  ;; Register a Jaeger Tracer configured from environment
+  (register-global-tracer!
+    (com.uber.jaeger.Configuration/fromEnv))
+
+  
+  ;; Sample Recursive functions with randomized
+  ;; execution time.
+  (let [f1 (trace/fn f1 [a b]
+             (Thread/sleep (rand-int 50))
+             (+ a b))
+         f2 (trace/fn f2 ([] 0)
+                   ([a] a)
+                   ([a b] (f1 a b))
+                   ([a b & more]
+                     (reduce f2 a (cons b more))))]
+     (f2 1 2 3 4 5 6 7))
+
+  )

--- a/src/naphthalimide/internal.clj
+++ b/src/naphthalimide/internal.clj
@@ -52,3 +52,27 @@
                     (:arglists (meta f#)))
        (var ~name))))
 
+
+(defn destruct-syms
+  [binding]
+  (remove #{'&}
+          ((fn syms [x]
+             (cond (symbol? x) [x]
+                   (coll? x)   (mapcat syms x)))
+            binding)))
+
+
+
+(defn meta-from
+  [expr meta-source]
+  (vary-meta expr merge
+             (meta meta-source)))
+
+
+(defn namespaced-name
+  [sym]
+  (if (and (instance? clojure.lang.Named sym)
+           (some? (namespace sym)))
+    (str sym)
+    (recur (symbol (str (ns-name *ns*))
+                   (name sym)))))

--- a/src/naphthalimide/internal.clj
+++ b/src/naphthalimide/internal.clj
@@ -15,12 +15,12 @@
 (defmacro definline*
   "Multi-arity form of clojure.core/definline"
   [name & decl]
-  (let [{:keys [prelude arities]} (parse-fn decl)]
+  (let [{:keys [prelude arities]} (parse-fn decl)
+        macro (eval (cons `fn arities))]
     `(do
        (defn ~name ~@prelude
-         ~@(let [macro (eval (cons `fn arities))]
-             (for [[argv] arities]
-               (list argv (apply macro argv)))))
+         ~@(for [[argv] arities]
+             (list argv (apply macro argv))))
        (alter-meta! (var ~name) assoc :inline (fn ~name ~@arities))
        (var ~name))))
 

--- a/test/naphthalimide/alpha/carrier_test.clj
+++ b/test/naphthalimide/alpha/carrier_test.clj
@@ -1,5 +1,5 @@
 (ns naphthalimide.alpha.carrier-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer []]
             [naphthalimide.alpha.carrier :as carrier]
             ))
 

--- a/test/naphthalimide/alpha/span_test.clj
+++ b/test/naphthalimide/alpha/span_test.clj
@@ -50,29 +50,26 @@
            (span/to-string (range))))
 
     (is (= "{:a 1, :b 2, :c 3, :d 4, :e 5}"
-       (span/to-string {:a 1 :b 2 :c 3 :d 4 :e 5})))
-    )
+           (span/to-string {:a 1 :b 2 :c 3 :d 4 :e 5}))))
   
   (binding [span/*sequence-length* 2]
-    (= "{:a (0 1 2 ...), :b (0 1 2 ...), ...}"
-       (span/to-string (zipmap [:a :b :c :d :e :f]
-                               (repeatedly range)))))
-
-  )
+    (is (= "{:a (0 1 ...), :b (0 1 ...), ...}"
+           (span/to-string (zipmap [:a :b :c :d :e :f]
+                                   (repeatedly range)))))))
 
 
 (deftest test-set-tag!
   (tracer/with-tracer (mock/tracer)
     (are [k input-v expected-v]
-         (let [span (span/start "me")]
-           (span/set-tag! span k input-v)
-           (= expected-v (get-in (mock/to-map span)
-                                 [:tags (keyword k)])))
+      (let [span (span/start "me")]
+        (span/set-tag! span k input-v)
+        (is (= expected-v (get-in (mock/to-map span)
+                                  [:tags (keyword k)]))))
 
-         :key     123  123
-         "bool"   true true
-         'null    nil  nil
-         "double" 3.45 3.45
-         "ratio"  1/3  1/3
-         :vector  [1 2 3 4] "[1 2 3 ...]"
-         )))
+      :key     123  123
+      "bool"   true true
+      'null    nil  nil
+      "double" 3.45 3.45
+      "ratio"  1/3  1/3
+      :vector  [1 2 3 4] "[1 2 3 ...]"
+      )))

--- a/test/naphthalimide/alpha/span_test.clj
+++ b/test/naphthalimide/alpha/span_test.clj
@@ -1,5 +1,5 @@
 (ns naphthalimide.alpha.span-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [are deftest is]]
             [naphthalimide.alpha.span :as span]
             [naphthalimide.alpha.tracer :as tracer]
             [naphthalimide.alpha.tracer.mock :as mock]

--- a/test/naphthalimide/alpha/tracer_test.clj
+++ b/test/naphthalimide/alpha/tracer_test.clj
@@ -1,4 +1,4 @@
 (ns naphthalimide.alpha.tracer-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer []]
             [naphthalimide.alpha.tracer :as tracer]
             ))

--- a/test/naphthalimide/alpha_test.clj
+++ b/test/naphthalimide/alpha_test.clj
@@ -1,9 +1,8 @@
 (ns naphthalimide.alpha-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [are deftest is]]
             [matcher-combinators.matchers :as m]
             matcher-combinators.test
             [naphthalimide.alpha :as trace]
-            [naphthalimide.alpha.span :as span]
             [naphthalimide.alpha.tracer :as tracer]
             [naphthalimide.alpha.tracer.mock :as mock]
             ))
@@ -12,11 +11,11 @@
 (defn demo-span-fn
   [a b c]
   (trace/let-span outer-span
-              [{:keys [x y]} a
-               b b]
+    [{:keys [x y]} a
+     b b]
     (trace/let-span inner-span
-                [b b c c]
-      (str a b c))))
+      [b b c c]
+      (str a b c x y))))
 
 
 (deftest test-span

--- a/test/naphthalimide/beta_test.clj
+++ b/test/naphthalimide/beta_test.clj
@@ -1,5 +1,5 @@
 (ns naphthalimide.beta-test
-  (:require [clojure.test :refer :all]
+  (:require [clojure.test :refer [are deftest is]]
             [matcher-combinators.matchers :as m]
             matcher-combinators.test
             [naphthalimide.alpha.tracer :as tracer]
@@ -96,10 +96,12 @@
   ([a] a)
   ([^::trace/tag a ^::trace/tag b]
     (traced-fn-1 a b))
-  ([^{::trace/tag aa} a
-    ^{::trace/tag bb} b
-    & ^{::trace/tag others} more]
-    (reduce traced-fn-1 a (cons b more))))
+  ([^{::trace/tag aa} a1
+    ^{::trace/tag bb} b1
+    & ^{:abc 123
+        ::trace/tag others
+        :some "Thing"} more]
+    (reduce traced-fn-1 a1 (cons b1 more))))
 
 
 (trace/defn traced-fn-3

--- a/test/naphthalimide/beta_test.clj
+++ b/test/naphthalimide/beta_test.clj
@@ -1,10 +1,8 @@
-(ns naphthalimide.alpha-test
+(ns naphthalimide.beta-test
   (:require [clojure.test :refer :all]
-            [naphthalimide.alpha :as trace]
+            [naphthalimide.beta :as trace]
             [naphthalimide.alpha.span :as span]
-            [naphthalimide.alpha.tracer :as tracer]
-            [naphthalimide.alpha.tracer.mock :as mock]
-            ))
+            [naphthalimide.alpha.tracer.mock :as mock]))
 
 
 
@@ -38,17 +36,6 @@
   (list a b c d))
 
 
-(deftest test-traced-fns
-  (are [invocation expected-spans]
-    (trace/with-tracer (mock/tracer)
-      (try invocation (catch Exception _ nil))
-      (is (= expected-spans
-             (mock/finished-spans (tracer/global-tracer)))))
-
-    (traced-fn-1 1 2) []
-    ))
-
-
 (deftest test-nested-traced-fns
   (let [fn1 (trace/fn fn1 [a b] (+ a b))
         fn2 (trace/fn fn2
@@ -56,11 +43,12 @@
               ([a b & more] (reduce fn1 a (cons b more))))]
     (are [expected xform expr]
       (let [tracer (mock/tracer)]
-        (try expr (catch Exception e nil))
-        (= expected
-           (map xform (mock/finished-spans tracer))))
+        (trace/with-tracer tracer
+          (try expr (catch Exception e nil))
+          (is (= expected
+                 (map xform (mock/finished-spans tracer))))))
 
-      nil identity (traced-fn-1 :a :b)
+      [] identity (traced-fn-1 1 2)
       )))
 
 

--- a/test/naphthalimide/beta_test.clj
+++ b/test/naphthalimide/beta_test.clj
@@ -1,23 +1,92 @@
 (ns naphthalimide.beta-test
   (:require [clojure.test :refer :all]
-            [naphthalimide.beta :as trace]
-            [naphthalimide.alpha.span :as span]
-            [naphthalimide.alpha.tracer.mock :as mock]))
+            [matcher-combinators.matchers :as m]
+            matcher-combinators.test
+            [naphthalimide.alpha.tracer :as tracer]
+            [naphthalimide.alpha.tracer.mock :as mock]
+            [naphthalimide.beta :as trace])
+  (:import (io.opentracing Span)))
 
 
+(deftest test-span
+  (are [form expected]
+    (trace/with-tracer (mock/tracer)
+      (try form (catch Exception _ nil))
+      (is (match? expected (mock/finished-spans (trace/global-tracer)))))
 
-(defn demo-span-fn
-  [a b c]
-  (trace/let-span outer-span
-              [{:keys [x y]} a
-               b b]
-    (trace/let-span inner-span
-                [b b c c]
-      (str a b c))))
+    (is (= 3 (trace/span "a+b" {:a 1 :b 2} 3)))
+    [{:operation (str `a+b)
+      :context {:trace-id integer?
+                :span-id integer?}
+      :start-micros integer?
+      :finish-micros integer?
+      :tags {:a 1
+             :b 2
+             :source.ns "naphthalimide.beta-test"
+             :source.file "naphthalimide/beta_test.clj"}
+      :trace-id integer?}]
+
+    (is (= "something"
+           (trace/span "outer" {:a {:uno "one"}}
+             (trace/span "inner" {:b {:dos "two"}}
+               "something"))))
+    [{:operation (str `inner)
+      :tags {:b "{:dos \"two\"}"}}
+     {:operation (str `outer)
+      :tags {:a "{:uno \"one\"}"}}]
+
+    (is (thrown? IllegalArgumentException
+          (trace/span "throws" {:x :y}
+            (throw (IllegalArgumentException. "Boom!")))))
+    [{:operation "naphthalimide.beta-test/throws",
+      :context map?
+      :tags {:x ":y"
+             :error true}
+      :log [{:timestamp-micros integer?
+             :fields {"error.kind" "Exception",
+                      "error.object" #(instance? IllegalArgumentException %)}}]}]
+    ))
+
+
+(deftest test-let-span
+  (are [form expected]
+    (trace/with-tracer (mock/tracer)
+      (try form (catch Exception _ nil))
+      (is (match? expected (mock/finished-spans (trace/global-tracer)))))
+
+    (is (= 3 (trace/let-span "+ab" [a 1 b 2] (+ a b))))
+    [{:operation (str `+ab)
+      :context {:trace-id integer?
+                :span-id integer?}
+      :start-micros integer?
+      :finish-micros integer?
+      :tags {:a 1
+             :b 2
+             :source.ns "naphthalimide.beta-test"
+             :source.file "naphthalimide/beta_test.clj"}
+      :trace-id integer?}]
+
+    (is (= 4 (trace/let-span "ab++" [a 1 b (+ a 2)] (+ a b))))
+    [{:operation (str `ab++)
+      :tags {:a 1
+             :b 3}}]
+    (is (= 10 (trace/let-span "a" [a 2]
+                (trace/let-span "b" [b (+ a 3)]
+                  (* a b)))))
+    [{:operation (str `b)
+      :tags {:b 5}}
+     {:operation (str `a)
+      :tags {:a 2}}]
+    ))
+
+
+(trace/defn traced-fn-0
+  [a b]
+  (+ a b))
 
 
 (trace/defn traced-fn-1
-  [a b]
+  [a ^::trace/tag b]
   (+ a b))
 
 
@@ -25,31 +94,129 @@
   "docstring"
   ([] 0)
   ([a] a)
-  ([a b]
+  ([^::trace/tag a ^::trace/tag b]
     (traced-fn-1 a b))
-  ([a b & more]
+  ([^{::trace/tag aa} a
+    ^{::trace/tag bb} b
+    & ^{::trace/tag others} more]
     (reduce traced-fn-1 a (cons b more))))
 
 
 (trace/defn traced-fn-3
-  [[a b] {:keys [c d]}]
+  [[a ^::trace/tag b] {:keys [c ^::trace/tag d]}]
   (list a b c d))
 
 
-(deftest test-nested-traced-fns
-  (let [fn1 (trace/fn fn1 [a b] (+ a b))
-        fn2 (trace/fn fn2
-              ([a b] (fn1 a b))
-              ([a b & more] (reduce fn1 a (cons b more))))]
-    (are [expected xform expr]
-      (let [tracer (mock/tracer)]
-        (trace/with-tracer tracer
-          (try expr (catch Exception e nil))
-          (is (= expected
-                 (map xform (mock/finished-spans tracer))))))
+(deftest test-traced-fns
+  (are [invocation expected-spans]
+    (trace/with-tracer (mock/tracer)
+      (try invocation (catch Exception _ nil))
+      (is (match? expected-spans
+                  (mock/finished-spans (tracer/global-tracer)))))
 
-      [] identity (traced-fn-1 1 2)
-      )))
+    (traced-fn-0 1 2)
+    [{:operation (str `traced-fn-0)
+      :tags (m/equals {:source.ns "naphthalimide.beta-test"
+                       :source.file "naphthalimide/beta_test.clj"})}]
+
+    (traced-fn-1 1 2)
+    [{:operation (str `traced-fn-1)
+      :tags (m/equals {:b 2
+                       :source.ns "naphthalimide.beta-test"
+                       :source.file "naphthalimide/beta_test.clj"})}]
+
+    (traced-fn-1 "x" "y")
+    [{:operation (str `traced-fn-1)
+      :tags {:b "y"
+             :source.ns "naphthalimide.beta-test"
+             :source.file "naphthalimide/beta_test.clj"
+             :error true}
+      :log [{:fields {"error.kind" "Exception"
+                      "error.object" #(instance? ClassCastException %)}}]}]
+
+    (traced-fn-2)
+    [{:operation (str `traced-fn-2)
+      :tags (m/equals {:source.ns string?
+                       :source.file string?})}]
+
+    (traced-fn-2 :just-a)
+    [{:operation (str `traced-fn-2)
+      :tags (m/equals {:source.ns string?
+                       :source.file string?})}]
+
+    (traced-fn-2 8 9)
+    [{:operation (str `traced-fn-1)
+      :tags {:b 9}}
+     {:operation (str `traced-fn-2)
+      :tags (m/equals {:a 8
+                       :b 9
+                       :source.ns string?
+                       :source.file string?})}]
+
+    (traced-fn-2 1 2 3 4)
+    [{:operation (str `traced-fn-1)
+      :tags {:b 2}}
+     {:operation (str `traced-fn-1)
+      :tags {:b 3}}
+     {:operation (str `traced-fn-1)
+      :tags {:b 4}}
+     {:operation (str `traced-fn-2)
+      :tags (m/equals {:aa 1
+                       :bb 2
+                       :others "(3 4)"
+                       :source.ns string?
+                       :source.file string?})}]
+
+    (traced-fn-3 [1 2] {:c 3 :d 4})
+    [{:operation (str `traced-fn-3)
+      :tags (m/equals {:b 2
+                       :d 4
+                       :source.ns string?
+                       :source.file string?})}]
+    ))
+
+
+(defn span? [x]
+  (instance? Span x))
+
+
+(deftest test-log!
+  (are [form expected]
+    (trace/with-tracer (mock/tracer)
+      (is (span? form))
+      (is (match? expected
+                  (mock/finished-spans (tracer/global-tracer)))))
+
+    (trace/span "log1" (trace/log! "abc"))
+    [{:operation (str `log1)
+      :log [{:timestamp-micros integer?
+             :fields {"event" "abc"}}]}]
+
+    (trace/span "log2"
+      (trace/log! "aaa")
+      (trace/log! "bbb")
+      (trace/log! "ccc"))
+    [{:operation (str `log2)
+      :log [{:fields {"event" "aaa"}}
+            {:fields {"event" "bbb"}}
+            {:fields {"event" "ccc"}}]}]
+
+    (trace/span "log3"
+      (trace/log! {:a "map"
+                   :of :stuff
+                   :xyz 123
+                   :list [4 5 6]}))
+    [{:operation (str `log3)
+      :log [{:fields {"a"   "map"
+                      "of"  :stuff
+                      "xyz" 123
+                      "list" [4 5 6]}}]}]
+
+    (trace/span "log4" (trace/log! (trace/active-span)
+                                   "log message 4"))
+    [{:operation (str `log4)
+      :log [{:fields {"event" "log message 4"}}]}]
+    ))
 
 
 (defn jaeger-tracer


### PR DESCRIPTION
Created a `naphthalimide.beta` namespace.  The _beta_ implementation changes the contract of using function arguments as span tags.  In _beta_ function arguments will only be propagated as span tags when hinted with `:naphthalimide.beta/tag` metadata.